### PR TITLE
Added issue counter to JS and SCSS builds

### DIFF
--- a/config/scss-lint.yml
+++ b/config/scss-lint.yml
@@ -1,5 +1,6 @@
 exclude:
     - '/**/vendor/**'
+    - '/**/node_modules/**'
 
 linters:
     BangFormat:

--- a/tasks/js_bundle.js
+++ b/tasks/js_bundle.js
@@ -20,6 +20,8 @@ var xtend = require("xtend");
 var pathHelper = require("../lib/path-helper");
 var jsHintConfigHelper = require("../config/jshint");
 
+var totalIssues = 0;
+
 
 /**
  * Logs jsHint warnings to the console
@@ -36,6 +38,8 @@ var jsHintConfigHelper = require("../config/jshint");
  */
 function logJsHintWarning (errors)
 {
+    totalIssues += errors.length;
+
     var sourceFile = pathHelper.makeRelative(this.resourcePath);
     gulpUtil.log(gulpUtil.colors.yellow("jshint warning") + " in " + sourceFile);
 
@@ -61,6 +65,24 @@ function logJsHintWarning (errors)
 
         gulpUtil.log("");
     }
+}
+
+
+/**
+ * Reports the total amount of JavaScript issues detected by JsHint
+ */
+function reportTotalIssueCount ()
+{
+    var outputColor = gulpUtil.colors.green;
+    if (totalIssues > 0)
+    {
+        outputColor = gulpUtil.colors.red;
+    }
+
+    gulpUtil.log(gulpUtil.colors.yellow('»»'), 'Total JS issues:', outputColor(totalIssues));
+
+    // Reset the issue count so we don't increment it every time a file has been modified while it is being watched
+    totalIssues = 0;
 }
 
 
@@ -144,6 +166,11 @@ function compileSingleFile (filePath, isDebug, options)
                 hash: false,
                 cached: options.logCachedFiles
             }));
+
+            if (isDebug)
+            {
+                reportTotalIssueCount();
+            }
         }
     );
 }

--- a/tasks/scss.js
+++ b/tasks/scss.js
@@ -17,12 +17,63 @@ var cssMin = require("gulp-minify-css");
 var sass = require("gulp-sass");
 var xtend = require("xtend");
 var scssLint = require('gulp-scss-lint');
+var scssLintReporter = require('gulp-scss-lint/src/reporters.js');
 var autoprefixer = require("gulp-autoprefixer");
 var glob = require("glob");
 var sassHelpers = require("../lib/sass-helpers");
 var path = require("path");
 var gulpUtil = require("gulp-util");
 var pathHelper = require("../lib/path-helper");
+
+var totalIssues = 0;
+
+
+/**
+ * Wraps the default SCSS Lint Reporter and
+ * counts the total amount of issues
+ *
+ * @param {{
+ *      scsslint: {
+ *          success: bool,
+ *          errors: int,
+ *          warnings: int,
+ *          issues: Array.<{
+ *              line: int,
+ *              column: int,
+ *              severity: string,
+ *              reason: string,
+ *          }>
+ *      }}} file
+ */
+function issueCountReporter (file)
+{
+    if (!file.scsslint.success)
+    {
+        totalIssues += file.scsslint.issues.length;
+    }
+
+    scssLintReporter.defaultReporter(file);
+}
+
+
+/**
+ * Prints the total issue count to the stdout
+ *
+ * @returns {*}
+ */
+function reportTotalIssueCount ()
+{
+    var outputColor = gulpUtil.colors.green;
+    if (totalIssues > 0)
+    {
+        outputColor = gulpUtil.colors.red;
+    }
+
+    gulpUtil.log(gulpUtil.colors.yellow('»»'), 'Total CSS issues:', outputColor(totalIssues));
+
+    // Reset the issue count so we don't increment it every time a file has been modified while it is being watched
+    totalIssues = 0;
+}
 
 
 /**
@@ -78,10 +129,14 @@ function lintFiles (src)
 {
     gulp.src(src)
         .pipe(scssLint({
-            config: __dirname + "/../config/scss-lint.yml"
-        }));
+            config: __dirname + "/../config/scss-lint.yml",
+            customReport: issueCountReporter
+        }))
+        .on('end', function ()
+        {
+            reportTotalIssueCount();
+        });
 }
-
 
 
 /**

--- a/tasks/scss.js
+++ b/tasks/scss.js
@@ -132,6 +132,10 @@ function lintFiles (src)
             config: __dirname + "/../config/scss-lint.yml",
             customReport: issueCountReporter
         }))
+        .on('error', function (error)
+        {
+            gulpUtil.log(gulpUtil.colors.red('An error has occurred while executing scss-lint: ' + error.message));
+        })
         .on('end', reportTotalIssueCount);
 }
 

--- a/tasks/scss.js
+++ b/tasks/scss.js
@@ -132,10 +132,7 @@ function lintFiles (src)
             config: __dirname + "/../config/scss-lint.yml",
             customReport: issueCountReporter
         }))
-        .on('end', function ()
-        {
-            reportTotalIssueCount();
-        });
+        .on('end', reportTotalIssueCount);
 }
 
 


### PR DESCRIPTION
Added a simple way to print the total amount of SCSS and JS issues that have been detected by JsHint and SCSS-Lint.

Unfortunately I couldn't manage to print both statistics at the very end of both operations as they're both asynchronous. However, they'll be printed at the end of each single operation so it is still useful.
